### PR TITLE
Common: Add MakeUniquePtr specialization for arrays

### DIFF
--- a/Src/Engine/Common/Containers/UniquePtr.hpp
+++ b/Src/Engine/Common/Containers/UniquePtr.hpp
@@ -94,7 +94,6 @@ private:
     UniquePtrBase& operator=(const UniquePtrBase&) = delete;
 };
 
-
 /**
  * Unique pointer - single object.
  */
@@ -150,12 +149,29 @@ public:
 };
 
 
+namespace detail {
+    template<typename>
+    constexpr bool is_unbounded_array_v = false;
+    template<typename T>
+    constexpr bool is_unbounded_array_v<T[]> = true;
+
+    template<typename>
+    constexpr bool is_bounded_array_v = false;
+    template<typename T, size_t N>
+    constexpr bool is_bounded_array_v<T[N]> = true;
+} // namespace detail
+
 /**
  * Create unique pointer.
  */
-template<typename T, typename ... Args>
-NFE_INLINE UniquePtr<T> MakeUniquePtr(Args&& ... args);
+template<typename T, typename... Args>
+NFE_INLINE std::enable_if_t<!std::is_array<T>::value, UniquePtr<T>> MakeUniquePtr(Args&& ... args);
 
+template<typename T>
+NFE_INLINE std::enable_if_t<detail::is_unbounded_array_v<T>, UniquePtr<T>> MakeUniquePtr(size_t n);
+
+template<typename T, typename... Args>
+NFE_INLINE std::enable_if_t<detail::is_bounded_array_v<T>, UniquePtr<T>> MakeUniquePtr(Args&& ...) = delete;
 
 /**
  * Static cast a unique pointer.

--- a/Src/Engine/Common/Containers/UniquePtrImpl.hpp
+++ b/Src/Engine/Common/Containers/UniquePtrImpl.hpp
@@ -179,11 +179,19 @@ UniquePtr<T[], Deleter>::operator UniquePtr<U[]>()
 
 //////////////////////////////////////////////////////////////////////////
 
-template<typename T, typename ... Args>
-UniquePtr<T> MakeUniquePtr(Args&& ... args)
+template<typename T, typename... Args>
+std::enable_if_t<!std::is_array<T>::value, UniquePtr<T>> MakeUniquePtr(Args&& ... args)
 {
     return UniquePtr<T>(new T(std::forward<Args>(args) ...));
 }
+
+template<typename T>
+std::enable_if_t<detail::is_unbounded_array_v<T>, UniquePtr<T>> MakeUniquePtr(size_t n)
+{
+    return UniquePtr<T>(new std::remove_extent_t<T>[n]());
+}
+
+//////////////////////////////////////////////////////////////////////////
 
 template<typename T, typename U>
 UniquePtr<T> StaticCast(UniquePtr<U>&& source)

--- a/Src/Tests/CommonTest/TestCases/Containers/UniquePtrTest.cpp
+++ b/Src/Tests/CommonTest/TestCases/Containers/UniquePtrTest.cpp
@@ -235,6 +235,24 @@ TEST(UniquePtr, ArrayType)
     EXPECT_EQ(1, counterB);
 }
 
+TEST(UniquePtr, MakeUniquePtrArrayType)
+{
+    int counterA = 0;
+    int counterB = 0;
+
+    {
+        UniquePtr<TestClass[]> pointer = MakeUniquePtr<TestClass[]>(2);
+        pointer[0].SetCounter(&counterA);
+        pointer[1].SetCounter(&counterB);
+
+        ASSERT_NE(pointer, nullptr);
+        ASSERT_TRUE(pointer);
+    }
+
+    EXPECT_EQ(1, counterA);
+    EXPECT_EQ(1, counterB);
+}
+
 TEST(UniquePtr, CastToBaseClass_Array)
 {
     int counterA = 0;


### PR DESCRIPTION
Dodałem odpowiednik:
`std::unique_ptr<uint8[]> data = std::make_unique<uint8[]>(size);`
żeby nie trzeba było robić:
`std::unique_ptr<uint8[]> data(new uint8[size]);`